### PR TITLE
Rename update button

### DIFF
--- a/resources/views/livewire/chirp-item.blade.php
+++ b/resources/views/livewire/chirp-item.blade.php
@@ -46,7 +46,7 @@
                 >{{ old('message') }}</textarea>
                 <x-input-error :messages="$errors->get('message')" class="mt-2" />
 
-                <x-primary-button class="mt-4 bg-indigo-500">{{ __('Edit Chirp') }}</x-primary-button>
+                <x-primary-button class="mt-4 bg-indigo-500">{{ __('Update Chirp') }}</x-primary-button>
                 <x-primary-button class="mt-4" type='reset' wire:click="cancel()">{{ __('Cancel') }}</x-primary-button>
             </form>
 


### PR DESCRIPTION
Fixed and changed the correct name(update chirp) of the action button for updating .

<img width="656" alt="2022-11-18 9 21 19" src="https://user-images.githubusercontent.com/52205108/202588036-58d591d0-1abc-4252-8c25-e886dd02573c.png">
